### PR TITLE
Generate po file with content to avoid generating invalid .mo files

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -58,7 +58,8 @@ def generate_blank_locale_files():
     for lang in '{{ cookiecutter.language_list }}'.split(','):
         os.mkdir('locale/{}'.format(lang))
         os.mkdir('locale/{}/LC_MESSAGES'.format(lang))
-        open('locale/{}/LC_MESSAGES/django.po'.format(lang), 'w').close()
+        shutil.copy('locale/base.po', 'locale/{}/LC_MESSAGES/django.po'.format(lang))
+    os.remove('locale/base.po')
 
 
 def install_ci_drifter_files():

--- a/{{cookiecutter.project_slug}}/locale/base.po
+++ b/{{cookiecutter.project_slug}}/locale/base.po
@@ -1,0 +1,5 @@
+msgid "de"
+msgstr ""
+
+msgid "en"
+msgstr ""


### PR DESCRIPTION
When compiling blank .po files, gettext will generate blank .mo files which are invalid and prevent django from starting.